### PR TITLE
Set CMAKE_INSTALL_LIBDIR to lib.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS  "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
+set(CMAKE_INSTALL_LIBDIR "lib") # lib prefix workaround for multi-arch
+
 find_package(OpenCV QUIET)
 
 aux_source_directory(common COMMON_SRC)


### PR DESCRIPTION
When migrating Rolling to new platforms in https://github.com/ros/rosdistro/pull/32036 a problem with the migration script (https://github.com/ros/rosdistro/issues/32128) caused patches on release/, rpm/, and debian/ branches to be wiped out.

I took a backup before the migration and am in the process of re-applying lost patches and this is one of them.

@wxmerkt with your approval I'll merge this PR and then bloom a debinc / release revision of apriltag in order to restore this patch behavior. If this patch shouldn't be restored for some reason then this PR can just be closed.

Thanks and apologies for the churn.